### PR TITLE
libmctp-intel: Remove -Werror from build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ project (libmctp)
 set(CMAKE_C_FLAGS
     "${CMAKE_C_FLAGS} \
     -Wall \
-    -Werror \
     -Wextra \
     -Wunused \
     -Wnull-dereference \


### PR DESCRIPTION
Clang finds more warnings which causes build to fail, disable treating warning as errors after boost from 1.78.0 to 1.81.0 and sdbusplus from C++17 to C++20